### PR TITLE
Add GitHub corner link

### DIFF
--- a/header.html
+++ b/header.html
@@ -1,4 +1,11 @@
 <header class="site-header" id="masthead">
+    <a class="github-corner" href="https://github.com/PatMyron/patmyron.github.io" aria-label="View source on GitHub">
+        <svg width="80" height="80" viewBox="0 0 250 250" aria-hidden="true">
+            <path d="M0 0l115 115h15l12 27 108 108V0z"></path>
+            <path class="octo-arm" d="M128.3 109c-14.5-9.8-18.8-23.3-18.8-23.3-2.3-10.4 1-16.9 1-16.9 6.4.7 9.9 2.9 9.9 2.9 9-6.4 17.3-4.6 17.3-4.6 0 6.5-3.5 11.4-3.5 11.4 5.6 6.2 3.8 13.8 3.8 13.8-4.8.3-8.4-1.7-8.4-1.7"></path>
+            <path class="octo-body" d="M115 115c-.4.3-.9.6-1.4.9-6.8 4.2-9.9 2.7-11.4.3-1.1-1.8-1.2-4.1-.5-5.4 2.1-4 5.3-4.8 5.3-4.8-3.8-6.6-4.7-13.5-1.4-17.1 3.3-3.5 10.6-2.6 17.8 2.4"></path>
+        </svg>
+    </a>
     <a href="https://patmyron.com">
         <h1 class="site-title">Pat Myron</h1>
     </a>

--- a/style.css
+++ b/style.css
@@ -99,6 +99,7 @@ img {
 ----------------------------------------------- */
 .site-header {
     background-color: #000;
+    position: relative;
 }
 
 .site-title {
@@ -295,4 +296,51 @@ p.landingPic img {
 
 .fa-stack-2x {
     color: #FFF;
+}
+
+.github-corner svg {
+    border: 0;
+    color: #000;
+    fill: #fff;
+    position: absolute;
+    right: 0;
+    top: 0;
+    z-index: 1;
+}
+
+.github-corner .octo-arm,
+.github-corner .octo-body {
+    fill: currentColor;
+}
+
+.github-corner .octo-arm {
+    transform-origin: 130px 106px;
+}
+
+.github-corner:hover .octo-arm {
+    animation: octocat-wave 560ms ease-in-out;
+}
+
+@keyframes octocat-wave {
+    0%, 100% {
+        transform: rotate(0);
+    }
+
+    20%, 60% {
+        transform: rotate(-25deg);
+    }
+
+    40%, 80% {
+        transform: rotate(10deg);
+    }
+}
+
+@media (max-width: 500px) {
+    .github-corner:hover .octo-arm {
+        animation: none;
+    }
+
+    .github-corner .octo-arm {
+        animation: octocat-wave 560ms ease-in-out;
+    }
 }


### PR DESCRIPTION
## Summary
- add a GitHub corner link to the shared site header
- keep the corner self-contained in the existing static HTML/CSS
- include the standard hover animation and mobile fallback

Fixes #7

## Bounty
Submitting under your standing bounty program.

PayPal: https://paypal.me/ShaimaaElkadi

## Testing
- `git diff --check`
