### PR TITLE
Add PR preview artifact workflow

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,0 +1,23 @@
+name: PR preview
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/jekyll-build-pages@v1
+        with:
+          source: .
+          destination: ./_site
+      - uses: actions/upload-artifact@v4
+        with:
+          name: pr-preview
+          path: ./_site
+          if-no-files-found: error
+          retention-days: 7


### PR DESCRIPTION
## Summary
- add a pull request workflow that builds the Jekyll site
- upload the built `_site` directory as a short-lived `pr-preview` artifact
- avoid requiring third-party hosting credentials for the first preview path

Fixes #12

## Bounty
Submitting under your standing bounty program.

PayPal: https://paypal.me/ShaimaaElkadi

## Testing
- `git diff --check`
